### PR TITLE
replaced org.json by io.github.ralfspoeth.json; added module-info.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Project exclude paths
 /target/
+.idea/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This application runs with Java 21.
 To start the application use the following command:
 
 ```shell
-export PATH_TO_JSON=${HOME}/.m2/repository/org/json/json/20231013
+export PATH_TO_JSON=${HOME}/.m2/repository/io/github/ralfspoeth/json/1.0.8
+export PATH_TO_BASIX=${HOME}/.m2/repository/io/github/ralfspoeth/basix/1.0.8
         
-java -classpath target/classes:$PATH_TO_JSON/json-20231013.jar \
+java -classpath target/classes:$PATH_TO_JSON/json-1.0.8.jar:$PATH_TO_BASIX/basix-1.0.8.jar \
         --enable-preview --source 21 \
         src/main/java/org/ammbra/advent/Wrapup.java
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java>21</java>
-        <exec.mainClass>org.ammbra.advent.Wrapup</exec.mainClass>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,21 +7,19 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java>21</java>
-        <json.version>20231013</json.version>
         <exec.mainClass>org.ammbra.advent.Wrapup</exec.mainClass>
-        <junit-jupiter-api.version>5.7.0</junit-jupiter-api.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.json</groupId>
+            <groupId>io.github.ralfspoeth</groupId>
             <artifactId>json</artifactId>
-            <version>${json.version}</version>
+            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter-api.version}</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>io.github.ralfspoeth</groupId>
             <artifactId>json</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module wrapup {
+    requires io.github.ralfspoeth.json;
+    requires jdk.httpserver;
+    requires java.net.http;
+}

--- a/src/main/java/org/ammbra/advent/Wrapup.java
+++ b/src/main/java/org/ammbra/advent/Wrapup.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 
 
 public class Wrapup {
+    
     public void main() throws IOException {
         var server = HttpServer.create(
                 new InetSocketAddress("", 8081), 0);

--- a/src/main/java/org/ammbra/advent/Wrapup.java
+++ b/src/main/java/org/ammbra/advent/Wrapup.java
@@ -1,7 +1,6 @@
 package org.ammbra.advent;
 
 import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import io.github.ralfspoeth.json.Element;
 import io.github.ralfspoeth.json.JsonObject;
@@ -22,73 +21,69 @@ import java.util.Currency;
 import java.util.concurrent.Executors;
 
 
-class Wrapup implements HttpHandler {
+public class Wrapup {
+    public void main() throws IOException {
+        var server = HttpServer.create(
+                new InetSocketAddress("", 8081), 0);
+        var address = server.getAddress();
+        server.createContext("/", this::handle);
+        server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
+        server.start();
+        System.out.printf("http://%s:%d%n", address.getHostString(), address.getPort());
+    }
 
-	void main() throws IOException {
-		var server = HttpServer.create(
-				new InetSocketAddress("", 8081), 0);
-		var address = server.getAddress();
-		server.createContext("/", new Wrapup());
-		server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
-		server.start();
-		System.out.printf("http://%s:%d%n",address.getHostString(), address.getPort());
-	}
 
+    private void handle(HttpExchange exchange) throws IOException {
+        int statusCode = 200;
 
-	@Override
-	public void handle(HttpExchange exchange) throws IOException {
-		int statusCode = 200;
+        if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+            statusCode = 400;
+        }
 
-		if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
-			statusCode = 400;
-		}
+        // Get the request body input stream
+        try (var rdr = new JsonReader(new InputStreamReader(exchange.getRequestBody()));
+             var wrtr = JsonWriter.createDefaultWriter(new OutputStreamWriter(exchange.getResponseBody()))
+        ) {
+            var req = (JsonObject) rdr.readElement();
+            var data = RequestConverter.convert(req);
 
-		// Get the request body input stream
-		try(var rdr = new JsonReader(new InputStreamReader(exchange.getRequestBody()));
-			var wrtr = JsonWriter.createDefaultWriter(new OutputStreamWriter(exchange.getResponseBody()))
-		)
-		{
-			var req = (JsonObject)rdr.readElement();
-			var data = RequestConverter.convert(req);
+            Postcard postcard = new Postcard(data.sender(), data.receiver(), data.celebration());
+            Intention intention = extractIntention(data);
+            var json = process(postcard, intention, data.choice());
 
-			Postcard postcard = new Postcard(data.sender(), data.receiver(), data.celebration());
-			Intention intention = extractIntention(data);
-			var json = process(postcard, intention, data.choice());
+            exchange.sendResponseHeaders(statusCode, 0);
 
-			exchange.sendResponseHeaders(statusCode, 0);
+            wrtr.write(json);
+        }
+    }
 
-			wrtr.write(json);
-		}
-	}
+    Intention extractIntention(RequestData data) {
+        return switch (data.choice()) {
+            case NONE -> new Coupon(0.0, null, Currency.getInstance("USD"));
+            case COUPON -> {
+                LocalDate localDate = LocalDateTime.now().plusYears(1).toLocalDate();
+                yield new Coupon(data.itemPrice(), localDate, Currency.getInstance("USD"));
+            }
+            case EXPERIENCE -> new Experience(data.itemPrice(), Currency.getInstance("EUR"));
+            case PRESENT -> new Present(data.itemPrice(), data.boxPrice(), Currency.getInstance("RON"));
+        };
+    }
 
-	Intention extractIntention(RequestData data) {
-		return switch (data.choice()) {
-			case NONE -> new Coupon(0.0, null, Currency.getInstance("USD"));
-			case COUPON -> {
-				LocalDate localDate = LocalDateTime.now().plusYears(1).toLocalDate();
-				yield new Coupon(data.itemPrice(), localDate, Currency.getInstance("USD"));
-			}
-			case EXPERIENCE -> new Experience(data.itemPrice(), Currency.getInstance("EUR"));
-			case PRESENT -> new Present(data.itemPrice(), data.boxPrice(), Currency.getInstance("RON"));
-		};
-	}
+    Element process(Postcard postcard, Intention intention, Choice choice) {
+        Gift gift = new Gift(postcard, intention);
 
-	Element process(Postcard postcard, Intention intention, Choice choice) {
-		Gift gift = new Gift(postcard, intention);
-
-		return switch (gift) {
-			case Gift(Postcard _, Postcard _) -> {
-				String message = "You cannot send two postcards!";
-				throw new UnsupportedOperationException(message);
-			}
-			case Gift(Postcard p, Coupon c)
-					when (c.price() == 0.0) -> p.toJsonObject();
-			case Gift(_, Coupon _), Gift(_, Experience _),
-					Gift(_, Present _) -> {
-				String option = choice.name().toLowerCase();
-				yield gift.merge(option);
-			}
-		};
-	}
+        return switch (gift) {
+            case Gift(Postcard _, Postcard _) -> {
+                String message = "You cannot send two postcards!";
+                throw new UnsupportedOperationException(message);
+            }
+            case Gift(Postcard p, Coupon c)
+                    when (c.price() == 0.0) -> p.toJsonObject();
+            case Gift(_, Coupon _), Gift(_, Experience _),
+                    Gift(_, Present _) -> {
+                String option = choice.name().toLowerCase();
+                yield gift.merge(option);
+            }
+        };
+    }
 }
-

--- a/src/main/java/org/ammbra/advent/request/RequestConverter.java
+++ b/src/main/java/org/ammbra/advent/request/RequestConverter.java
@@ -1,13 +1,11 @@
 package org.ammbra.advent.request;
 
-import io.github.ralfspoeth.json.*;
-import io.github.ralfspoeth.json.io.JsonReader;
+import io.github.ralfspoeth.json.JsonObject;
 import org.ammbra.advent.surprise.Celebration;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Arrays;
+
+import static io.github.ralfspoeth.json.conv.StandardConversions.*;
 
 public final class RequestConverter {
 
@@ -19,47 +17,17 @@ public final class RequestConverter {
 
         if (jsonObject.members().keySet().containsAll(Arrays.asList("sender", "receiver", "celebration", "option"))) {
             for (String key : jsonObject.members().keySet()) {
-                var value = jsonObject.members().get(key);
+                var element = jsonObject.members().get(key);
                 switch (key) {
-                    case "sender" -> builder.sender(toString(value));
-                    case "receiver" -> builder.receiver(toString(value));
-                    case "celebration" -> builder.celebration(toEnum(Celebration.class, value));
-                    case "option" -> builder.choice(toEnum(Choice.class, value));
-                    case "itemPrice" -> builder.itemPrice(Math.abs(toDouble(value)));
-                    case "boxPrice" -> builder.boxPrice(Math.abs(toDouble(value)));
+                    case "sender" -> builder.sender(stringValue(element));
+                    case "receiver" -> builder.receiver(stringValue(element));
+                    case "celebration" -> builder.celebration(enumValue(Celebration.class, element));
+                    case "option" -> builder.choice(enumValue(Choice.class, element));
+                    case "itemPrice" -> builder.itemPrice(Math.abs(doubleValue(element)));
+                    case "boxPrice" -> builder.boxPrice(Math.abs(doubleValue(element)));
                 }
             }
         }
         return builder.build();
     }
-
-    public static <E extends Enum<E>> E toEnum(Class<E> enumClass, Element elem) {
-        return switch (elem) {
-            case JsonString str -> Enum.valueOf(enumClass, str.value().toUpperCase());
-			case null -> null;
-            default -> throw new RuntimeException(STR."cannot convert \{elem} to Choice");
-        };
-    }
-
-    public static double toDouble(Element elem) {
-        return switch(elem) {
-            case JsonNumber num -> num.numVal();
-            case JsonString str -> Double.parseDouble(str.value());
-            default -> throw new RuntimeException(STR."cannot convert \{elem} to double");
-        };
-    }
-
-    public static String toString(Element elem) {
-        return switch (elem) {
-            case null -> "";
-            default -> elem.toString();
-        };
-    }
-
-    public static JsonObject parse(InputStream reqBody) throws IOException {
-        try (var r = new JsonReader(new InputStreamReader(reqBody))) {
-            return (JsonObject)r.readElement();
-        }
-    }
-
 }

--- a/src/main/java/org/ammbra/advent/surprise/Coupon.java
+++ b/src/main/java/org/ammbra/advent/surprise/Coupon.java
@@ -1,9 +1,12 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
+import io.github.ralfspoeth.json.JsonObject;
+
 import java.time.LocalDate;
 import java.util.Currency;
 import java.util.Objects;
+
+import static io.github.ralfspoeth.json.Aggregate.objectBuilder;
 
 public record Coupon(double price, LocalDate expiringOn, Currency currency)
 		implements Intention {
@@ -16,13 +19,11 @@ public record Coupon(double price, LocalDate expiringOn, Currency currency)
 	}
 
 	@Override
-	public JSONObject asJSON() {
-		return JSON. """
-				{
-				    "currency": "\{currency}",
-				    "expiresOn" : "\{ expiringOn}",
-				    "cost": "\{price}"
-				}
-				""" ;
+	public JsonObject toJsonObject() {
+		return objectBuilder()
+				.named("currency", currency)
+				.named("expiresOn", expiringOn)
+				.named("cost", price)
+				.build();
 	}
 }

--- a/src/main/java/org/ammbra/advent/surprise/Experience.java
+++ b/src/main/java/org/ammbra/advent/surprise/Experience.java
@@ -1,28 +1,27 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
+import io.github.ralfspoeth.json.JsonObject;
 
 import java.util.Currency;
 import java.util.Objects;
 
+import static io.github.ralfspoeth.json.Aggregate.objectBuilder;
+
 public record Experience(double price, Currency currency) implements Intention {
 
-	public Experience {
-		Objects.requireNonNull(currency, "currency is required");
-		if (price < 0) {
-			throw new IllegalArgumentException("Price of an item cannot be negative");
-		}
-	}
+    public Experience {
+        Objects.requireNonNull(currency, "currency is required");
+        if (price < 0) {
+            throw new IllegalArgumentException("Price of an item cannot be negative");
+        }
+    }
 
-	@Override
-	public JSONObject asJSON() {
-
-		return JSON. """
-				{
-				    "currency": "\{currency}",
-				    "cost": "\{price}"
-				}
-				""" ;
-	}
+    @Override
+    public JsonObject toJsonObject() {
+        return objectBuilder()
+                .named("currency", currency)
+                .named("cost", price)
+                .build();
+    }
 
 }

--- a/src/main/java/org/ammbra/advent/surprise/Gift.java
+++ b/src/main/java/org/ammbra/advent/surprise/Gift.java
@@ -1,17 +1,17 @@
 package org.ammbra.advent.surprise;
 
-import io.github.ralfspoeth.json.Aggregate;
 import io.github.ralfspoeth.json.JsonObject;
+
+import java.util.HashMap;
 
 public record Gift(Postcard postcard, Intention intention) {
 
 	public JsonObject merge(String option) {
-		var intentionJSON = intention.toJsonObject();
-		var ob = Aggregate.objectBuilder();
-		var pc = postcard.toJsonObject();
-		pc.members().entrySet().forEach(e -> ob.named(e.getKey(), e.getValue()));
-		ob.named(option, intentionJSON);
-		return ob.build();
+		var intntnJson = intention.toJsonObject();
+		var pcJson = postcard.toJsonObject();
+		var m = new HashMap<>(pcJson.members());
+		m.put(option, intntnJson);
+		return new JsonObject(m); // makes an immutable copy internally
 	}
 }
 

--- a/src/main/java/org/ammbra/advent/surprise/Gift.java
+++ b/src/main/java/org/ammbra/advent/surprise/Gift.java
@@ -1,13 +1,17 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
-
+import io.github.ralfspoeth.json.Aggregate;
+import io.github.ralfspoeth.json.JsonObject;
 
 public record Gift(Postcard postcard, Intention intention) {
 
-	public JSONObject merge(String option) {
-		JSONObject intentionJSON = intention.asJSON();
-		return postcard.asJSON().put(option, intentionJSON);
+	public JsonObject merge(String option) {
+		var intentionJSON = intention.toJsonObject();
+		var ob = Aggregate.objectBuilder();
+		var pc = postcard.toJsonObject();
+		pc.members().entrySet().forEach(e -> ob.named(e.getKey(), e.getValue()));
+		ob.named(option, intentionJSON);
+		return ob.build();
 	}
 }
 

--- a/src/main/java/org/ammbra/advent/surprise/Intention.java
+++ b/src/main/java/org/ammbra/advent/surprise/Intention.java
@@ -1,13 +1,9 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
+import io.github.ralfspoeth.json.JsonObject;
 
 public sealed interface Intention
-		permits Coupon, Experience, Present, Postcard {
-
-	StringTemplate.Processor<JSONObject, RuntimeException> JSON = StringTemplate.Processor.of(
-			(StringTemplate st) -> new JSONObject(st.interpolate())
-	);
-
-	JSONObject asJSON();
+		permits Coupon, Experience, Present, Postcard
+{
+	JsonObject toJsonObject();
 }

--- a/src/main/java/org/ammbra/advent/surprise/Postcard.java
+++ b/src/main/java/org/ammbra/advent/surprise/Postcard.java
@@ -1,7 +1,10 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
+import io.github.ralfspoeth.json.JsonObject;
+
 import java.util.Objects;
+
+import static io.github.ralfspoeth.json.Aggregate.objectBuilder;
 
 public record Postcard(String sender, String receiver, Celebration celebration) implements Intention {
 
@@ -11,14 +14,12 @@ public record Postcard(String sender, String receiver, Celebration celebration) 
 		Objects.requireNonNull(celebration, "celebration is required");
 	}
 
-	public JSONObject asJSON() {
-		return JSON. """
-				{
-					"sender": "\{sender}",
-				    "receiver": "\{receiver}",
-				    "message": "\{celebration.getText()}"
-				}
-				""" ;
+	public JsonObject toJsonObject() {
+		return objectBuilder()
+				.named("sender", sender)
+				.named("receiver", receiver)
+				.named("celebration", celebration)
+				.build();
 	}
 
 }

--- a/src/main/java/org/ammbra/advent/surprise/Present.java
+++ b/src/main/java/org/ammbra/advent/surprise/Present.java
@@ -1,31 +1,31 @@
 package org.ammbra.advent.surprise;
 
-import org.json.JSONObject;
+import io.github.ralfspoeth.json.JsonObject;
+
 import java.util.Currency;
 import java.util.Objects;
 
+import static io.github.ralfspoeth.json.Aggregate.objectBuilder;
+
 public record Present(double itemPrice, double boxPrice,
-					  Currency currency) implements Intention {
+                      Currency currency) implements Intention {
 
-	public Present {
-		Objects.requireNonNull(currency, "currency is required");
-		if (itemPrice < 0) {
-			throw new IllegalArgumentException("Price of an item cannot be negative");
-		} else if (boxPrice < 0) {
-			throw new IllegalArgumentException("Price of the box cannot be negative");
-		}
-	}
+    public Present {
+        Objects.requireNonNull(currency, "currency is required");
+        if (itemPrice < 0) {
+            throw new IllegalArgumentException("Price of an item cannot be negative");
+        } else if (boxPrice < 0) {
+            throw new IllegalArgumentException("Price of the box cannot be negative");
+        }
+    }
 
-	@Override
-	public JSONObject asJSON() {
-
-		return JSON. """
-				{
-				    "currency": "\{currency}",
-				    "boxPrice": "\{boxPrice}",
-				    "packaged" : "\{ boxPrice > 0.0}",
-				    "cost": "\{(boxPrice > 0.0) ? itemPrice + boxPrice : itemPrice}"
-				}
-				""" ;
-	}
+    @Override
+    public JsonObject toJsonObject() {
+        return objectBuilder()
+                .named("currency", currency)
+                .named("boxPrice", boxPrice)
+                .named("packaged", boxPrice > 0)
+                .named("cost", (boxPrice > 0) ? itemPrice + boxPrice : itemPrice)
+                .build();
+    }
 }


### PR DESCRIPTION
This commit replaces the use of the `JSONObject` implementation in `org.json` with an implementation of JSON data using a sealed hierarchy of immutable data types utilizing records, builders for aggregate types (JsonObject and JsonArray) and a quite light-weight parser, in my `io.github.ralfspoeth.json` repository on [github](https://github.com/ralfspoeth/json).

Please feel free to reject or ignore this request; or feel free to use (and comment or review) the JSON implementation used herein.